### PR TITLE
docs: Update chat command documentation with checkpoint locations

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -17,6 +17,11 @@ Slash commands provide meta-level control over the CLI itself.
     - **`save`**
       - **Description:** Saves the current conversation history. You must add a `<tag>` for identifying the conversation state.
       - **Usage:** `/chat save <tag>`
+      - **Details on Checkpoint Location:** The default locations for saved chat checkpoints are:
+          - `Linux/macOS: ~/.config/google-generative-ai/checkpoints/`
+          - `Windows: C:\Users\<YourUsername>\AppData\Roaming\google-generative-ai\checkpoints\`
+          - When you run `/chat list`, the CLI only scans these specific directories to find available checkpoints.
+
     - **`resume`**
       - **Description:** Resumes a conversation from a previous save.
       - **Usage:** `/chat resume <tag>`


### PR DESCRIPTION
Why: To address user confusion about where chat checkpoints are stored and to improve clarity for managing saved conversations.

What: This pull request clarifies the documentation for the /chat command by adding specific details about the default checkpoint save locations for Linux/macOS and Windows, and clarifies that the list sub-command only scans these directories.


